### PR TITLE
Decode return type is dict[str, Any]

### DIFF
--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -4,7 +4,7 @@ from calendar import timegm
 from datetime import datetime, timedelta
 try:
     # import required by mypy to perform type checking, not used for normal execution
-    from typing import Callable, Dict, List, Optional, Union # NOQA
+    from typing import Any, Callable, Dict, List, Optional, Union # NOQA
 except ImportError:
     pass
 
@@ -72,6 +72,7 @@ class PyJWT(PyJWS):
                algorithms=None,  # type: List[str]
                options=None,  # type: Dict
                **kwargs):
+        # type: (...) -> Dict[Any, Any]
 
         if verify and not algorithms:
             warnings.warn(
@@ -96,7 +97,7 @@ class PyJWT(PyJWS):
             payload = json.loads(decoded.decode('utf-8'))
         except ValueError as e:
             raise DecodeError('Invalid payload string: %s' % e)
-        if not isinstance(payload, Mapping):
+        if not isinstance(payload, dict):
             raise DecodeError('Invalid payload string: must be a json object')
 
         if verify:

--- a/jwt/api_jwt.py
+++ b/jwt/api_jwt.py
@@ -72,7 +72,7 @@ class PyJWT(PyJWS):
                algorithms=None,  # type: List[str]
                options=None,  # type: Dict
                **kwargs):
-        # type: (...) -> Dict[Any, Any]
+        # type: (...) -> Dict[str, Any]
 
         if verify and not algorithms:
             warnings.warn(


### PR DESCRIPTION
As discussed [here](https://github.com/jpadilla/pyjwt/issues/392) the return type for `decode` should be `dict[str, Any]` instead of the (inferred) `Mapping[any, any]`, this adds it.

Mapping is an ABC and I think the check with `isinstance` maybe was more appropriate, but still we know it is going to be a dictionary in any case so should be fine.